### PR TITLE
missing range int the example

### DIFF
--- a/example/dhcpd.conf
+++ b/example/dhcpd.conf
@@ -6,6 +6,7 @@ max-lease-time 7200;
 subnet 192.168.0.0 netmask 255.255.255.0 {
 	option routers 192.168.0.1;
 	option subnet-mask 255.255.255.0;
+	range 192.168.0.10 192.168.0.254;
 	option broadcast-address 192.168.0.255;
 	option domain-name-servers 192.168.0.1;
 	option domain-name "local.example.com";


### PR DESCRIPTION
This is required for the server to work out of the box with the given example.
If no range is specified no lease is attributed by the server : `no free leases` error